### PR TITLE
Add router option

### DIFF
--- a/cli/up.go
+++ b/cli/up.go
@@ -178,13 +178,20 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 	var stream network.Stream
 	var header *ipv4.Header
 	var plen int
+	var dst string
+	ip, _, err := net.ParseCIDR(cfg.Interface.Address)
+	checkErr(err)
 	for {
 		plen, err = iface.Read(packet)
 		checkErr(err)
 		header, _ = ipv4.ParseHeader(packet)
-		_, ok := cfg.Peers[header.Dst.String()]
+		dst = header.Dst.String()
+		if cfg.Interface.Router != "" && header.Src.Equal(ip) {
+			dst = cfg.Interface.Router
+		}
+		_, ok := cfg.Peers[dst]
 		if ok {
-			stream, err = host.NewStream(ctx, peerTable[header.Dst.String()], p2p.Protocol)
+			stream, err = host.NewStream(ctx, peerTable[dst], p2p.Protocol)
 			if err != nil {
 				log.Println(err)
 				continue

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Interface struct {
 	ID         string `yaml:"id"`
 	ListenPort int    `yaml:"listen_port"`
 	Address    string `yaml:"address"`
+	Router     string `yaml:"router"`
 	PrivateKey string `yaml:"private_key"`
 }
 
@@ -37,6 +38,7 @@ func Read(path string) (result Config, err error) {
 			Name:       "hs0",
 			ListenPort: 8001,
 			Address:    "10.1.1.1",
+			Router:     "",
 			ID:         "",
 			PrivateKey: "",
 		},


### PR DESCRIPTION
Hi @ , nice project!
This PR adds possibility to optionally set one of the remote nodes as router / gateway and so allows to reach LAN networks behind the router or even use it as default gateway to forward Internet traffic via it.
In short it adds VPN functional in additional to existing mesh functional.

Examples
hs0.yaml
```yaml
interface:
  address: 10.0.2.2/24
  router: 10.0.2.1
...
```
Access LAN network 10.0.0.0/24
```
$ ip route add 10.0.0.0/24 dev hs0
$ ping -c 1 10.0.0.1
PING 10.0.0.1 (10.0.0.1) 56(84) bytes of data.
64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=7.63 ms
```
Access Internet (remote node should have configured forwarding and NAT)
```
# 17.5.7.8 is the public address of remote node
# 192.168.0.1 is the local router
$ ip route add 17.5.7.8 via 192.168.0.1
$ ip route add default dev hs0 metric 1
$ curl http://2ip.ru
17.5.7.8
```