### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-platforms=("linux/amd64" "linux/arm" "linux/arm64" "darwin/amd64" "darwin/arm64")
+platforms=("linux/amd64" "linux/arm" "linux/arm64" "darwin/amd64" "darwin/arm64" "windows/amd64" "windows/386")
 
 for platform in "${platforms[@]}"
 do
     platform_split=(${platform//\// })
     GOOS=${platform_split[0]}
     GOARCH=${platform_split[1]}
-    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH} .
+    [ $GOOS == "windows" ] && EXT=".exe"
+    env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/hyprspace/hyprspace/cli.appVersion=$1" -o hyprspace-$1-${GOOS}-${GOARCH}${EXT} .
 
 done

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you're running Hyprspace on a Mac you'll need to install `iproute2mac`. If yo
 ```bash
 brew install iproute2mac
 ```
+If you're running Hyprspace on Windows you'll need to install [tap-windows](http://build.openvpn.net/downloads/releases/).
 
 ### Installation
 
@@ -87,6 +88,8 @@ interface on our local machine `hs0` (for hypr-space 0) and `hs1` on our remote 
 but yours could be anything you'd like. 
 
 (Note: if you're using a Mac you'll have to use the interface name `utun[0-9]`. Check which interfaces are already in use by running `ip a` once you've got `iproute2mac` installed.)
+
+(Note: if you're using Windows you'll have to use the interface name as seen in Control Panel. IP address will be set automatically only if you run Hyprspace as Administrator.)
 
 ###### Local Machine
 ```bash

--- a/cli/up.go
+++ b/cli/up.go
@@ -98,7 +98,7 @@ func UpRun(r *cmd.Root, c *cmd.Sub) {
 
 	fmt.Println("[+] Creating TUN Device")
 	// Create new TUN device
-	iface, err = tun.New(cfg.Interface.Name)
+	iface, err = tun.New(cfg.Interface.Name, cfg.Interface.Address)
 	if err != nil {
 		checkErr(errors.New("interface already in use"))
 	}

--- a/tun/tun_windows.go
+++ b/tun/tun_windows.go
@@ -1,22 +1,38 @@
-//go:build !windows
-// +build !windows
+//go:build windows
+// +build windows
 
 package tun
 
 import (
-	"fmt"
 	"os/exec"
+	"net"
 
 	"github.com/songgao/water"
 )
 
 // New creates and returns a new TUN interface for the application.
 func New(name string, address string) (result *water.Interface, err error) {
+	// TUN on Windows requires address and network to be set on device creation stage
+	// We also set network to 0.0.0.0/0 so we able to reach networks behind the node
+	// https://github.com/songgao/water/blob/master/params_windows.go
+	// https://gitlab.com/openconnect/openconnect/-/blob/master/tun-win32.c
+	ip, _, err := net.ParseCIDR(address)
+	if err != nil {
+		return nil, err
+	}
+	network := net.IPNet{
+		IP:   ip,
+		Mask: net.IPv4Mask(0,0,0,0),
+	}
 	// Setup TUN Config
 	cfg := water.Config{
 		DeviceType: water.TUN,
+		PlatformSpecificParams: water.PlatformSpecificParams{
+			ComponentID:   "tap0901",
+			InterfaceName: name,
+			Network:       network.String(),
+		},
 	}
-	cfg.Name = name
 	// Create TUN Interface
 	result, err = water.New(cfg)
 	return
@@ -25,31 +41,31 @@ func New(name string, address string) (result *water.Interface, err error) {
 // SetMTU sets the Maximum Tansmission Unit Size for a
 // Packet on the interface.
 func SetMTU(name string, mtu int) (err error) {
-	return ip("link", "set", "dev", name, "mtu", fmt.Sprintf("%d", mtu))
+	return
 }
 
 // SetAddress sets the interface's known address and subnet.
 func SetAddress(name string, address string) (err error) {
-	return ip("addr", "add", address, "dev", name)
+	return netsh("interface", "ip", "set", "address", "name=", name, "static", address)
 }
 
 // Up brings up an interface to allow it to start accepting connections.
 func Up(name string) (err error) {
-	return ip("link", "set", "dev", name, "up")
+	return
 }
 
 // Down brings down an interface stopping active connections.
 func Down(name string) (err error) {
-	return ip("link", "set", "dev", name, "down")
+	return
 }
 
 // Delete removes a TUN device from the host.
 func Delete(name string) (err error) {
-	return ip("link", "delete", "dev", name)
+	return
 }
 
-func ip(args ...string) (err error) {
-	cmd := exec.Command("ip", args...)
+func netsh(args ...string) (err error) {
+	cmd := exec.Command("netsh", args...)
 	err = cmd.Run()
 	return
 }


### PR DESCRIPTION
Hi @ , nice project!
This PR adds Windows support to Hyprspace. Water library requires OpenVPN tap driver to be installed and so we too.

Examples
example.yaml
```yaml
interface:
  name: Ethernet 3
...
```
Start commands
```
hyprspace up example -f -c example.yaml
```